### PR TITLE
use SM integration and CLI

### DIFF
--- a/ingress.sh
+++ b/ingress.sh
@@ -29,6 +29,15 @@ function customdomain_https() {
     envsubst > ingress-customdomain-https.yaml
 }
 
+function customdomain_https_sm() {
+    cat yaml-templates/ingress-customdomain-https-sm-template.yaml | \
+    MYAPP=$MYAPP \
+    CUSTOM_SUBDOMAIN=$CUSTOM_SUBDOMAIN \
+    CUSTOM_SECRET_NAME=$CUSTOM_SECRET_NAME \
+    KUBERNETES_NAMESPACE=$KUBERNETES_NAMESPACE \
+    envsubst > ingress-customdomain-https.yaml
+}
+
 function log_error() {
     MSG="Unknown function or something went wrong...."
     printf "%s - [ERROR] %s\n" "$(date)" "$MSG" >&2
@@ -39,6 +48,7 @@ case "$1" in
     ibmsubdomain_https) "$@"; exit;;
     customdomain_http) "$@"; exit;;
     customdomain_https) "$@"; exit;;
+    customdomain_https_sm) "$@"; exit;;
     *) log_error "Unknown function: $1()"; exit 2;;
 esac
 

--- a/yaml-templates/ingress-customdomain-https-sm-template.yaml
+++ b/yaml-templates/ingress-customdomain-https-sm-template.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-for-customdomain-https
+  namespace: $KUBERNETES_NAMESPACE
+spec:
+  tls:
+  - hosts:
+    - $MYAPP.$CUSTOM_DOMAIN
+    secretName: nodeapp-tls-cert
+  rules:
+  - host: $MYAPP.$CUSTOM_DOMAIN
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetesnodeapp
+            port:
+              number: 3000


### PR DESCRIPTION
changes related to https://cloud.ibm.com/docs/solution-tutorials?topic=solution-tutorials-scalable-webapp-kubernetes#scalable-webapp-kubernetes-custom_domain and using the "native" SM integration instead of ESO

The TLS cert for the custom domain needs to be imported to SM. Then, it can be made available as secret:
```
ibmcloud ks ingress secret create --name nodeapp-tls-cert --cluster mycluster  --cert-crn crn:v1:bluemix:public:secrets-manager:eu-de:cern4tls:cert:some:value --namespace default
```

**nodeapp-tls-cert** is referenced in the YAML